### PR TITLE
Fix stop_newline -> stop_new_line attribute name mismatch

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -71,8 +71,8 @@ def run_test(args, model, dataset, test_file, demo_file):
         args.input_max_length += 32768
         model.max_length = args.input_max_length
         model.generation_max_length = args.generation_max_length
-        args.stop_newline = False
-        logger.info(f"thinking mode, adding 32k tokens to generation and input max length, also disabling stop_newline")
+        args.stop_new_line = False
+        logger.info(f"thinking mode, adding 32k tokens to generation and input max length, also disabling stop_new_line")
 
     logger.info("Running generation...")
     start_time = time.time()

--- a/model_utils.py
+++ b/model_utils.py
@@ -596,7 +596,7 @@ class GeminiModel(LLM):
             generation_max_length=generation_max_length,
             generation_min_length=generation_min_length,
             do_sample=do_sample,
-            stop_newline=stop_newline,
+            stop_new_line=stop_new_line,
             use_chat_template=use_chat_template,
             system_message=system_message,
         )
@@ -702,7 +702,7 @@ class TogetherModel(LLM):
             generation_max_length=generation_max_length,
             generation_min_length=generation_min_length,
             do_sample=do_sample,
-            stop_newline=stop_newline,
+            stop_new_line=stop_new_line,
             use_chat_template=use_chat_template,
             system_message=system_message,
         )
@@ -869,7 +869,7 @@ class HFModel(LLM):
             generation_max_length=generation_max_length,
             generation_min_length=generation_min_length,
             do_sample=do_sample,
-            stop_newline=stop_newline,
+            stop_new_line=stop_new_line,
             use_chat_template=use_chat_template,
             system_message=system_message,
         )
@@ -918,7 +918,7 @@ class HFModel(LLM):
         # use the default if possible, append if necessary
         stop_token_ids = self.model.generation_config.eos_token_id
         stop_token_ids = [stop_token_ids] if not isinstance(stop_token_ids, list) else stop_token_ids
-        if stop_newline:
+        if stop_new_line:
             stop = list(set(["\n", "Ċ", "ĊĊ", "<0x0A>"]))
             stop_token_ids = list(set([self.tokenizer.convert_tokens_to_ids(stop_token) for stop_token in stop] + stop_token_ids))
             if "llama" in model_name.lower():
@@ -1296,7 +1296,7 @@ def load_LLM(args):
         generation_max_length=args.generation_max_length,
         generation_min_length=args.generation_min_length,
         do_sample=args.do_sample,
-        stop_newline=args.stop_newline,
+        stop_new_line=args.stop_new_line,
         use_chat_template=args.use_chat_template,
         system_message=args.system_message,
         **kwargs,

--- a/scripts/run_api.sh
+++ b/scripts/run_api.sh
@@ -66,7 +66,7 @@ MODEL_NAME="${OD[$IDX]}"
 OUTPUT_DIR="output/$(basename $MODEL_NAME)"
 
 # for the API models we always use use_chat_template=True
-OPTIONS="--use_chat_template True --stop_newline False"
+OPTIONS="--use_chat_template True --stop_new_line False"
 
 echo "Evaluation output dir         = $OUTPUT_DIR"
 echo "Tag                           = $TAG"


### PR DESCRIPTION
## Summary
- Fixes the `AttributeError: 'Namespace' object has no attribute 'stop_newline'` crash reported in #38
- The argparse flag is `--stop_new_line` (producing `args.stop_new_line`), but several places used the misspelled `stop_newline` (missing underscore before "line")
- Fixed all 7 occurrences across `model_utils.py`, `eval.py`, and `scripts/run_api.sh`

## Files changed
- **`model_utils.py`**: Fixed `stop_newline` → `stop_new_line` in 3 `super().__init__()` calls, 1 conditional check, and the `load_LLM()` function
- **`eval.py`**: Fixed `args.stop_newline` → `args.stop_new_line` in thinking mode override
- **`scripts/run_api.sh`**: Fixed `--stop_newline` → `--stop_new_line` CLI flag

## Test plan
- [ ] Run `python eval.py --config configs/cite.yaml --model_name_or_path <model> --stop_new_line False` and confirm no AttributeError

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)