### PR TITLE
Seed few-shot demo sampling in narrativeqa and multi_lexsum

### DIFF
--- a/data.py
+++ b/data.py
@@ -181,6 +181,12 @@ def filter_length(data, min_length, key):
     return data
 
 
+def demo_seed(key, seed):
+    # a different seed for every sample, but deterministic and affected by the set seed
+    # hashlib is deterministic while hash() is not in Python>=3.3, the seed has to be a positive integer
+    return (int(hashlib.sha256(key.encode("utf-8")).hexdigest(), 16) + seed) % 2**31
+
+
 def load_narrativeqa(dataset, shots=0, max_samples=None, seed=42):
     user_template = "You are given a story, which can be either a novel or a movie script, and a question. Answer the question as concisely as you can, using a single phrase if possible.\n\n{demo}{context}\n\nQuestion: {question}"
     system_template = "Answer:"
@@ -199,7 +205,7 @@ def load_narrativeqa(dataset, shots=0, max_samples=None, seed=42):
         "context": example["document"]["text"],
         "question": example["question"]["text"],
         "answer": [ex["text"] for ex in example["answers"]],
-        "demo": "" if shots == 0 else "For example:\n\n" + "\n\n".join([f"Question: {ex['question']['text']}\nAnswer: {ex['answers'][0]['text']}" for ex in all_data["train"].shuffle().select(range(shots))]) + "\n\nNow, use the following story to answer the question:\n\n"
+        "demo": "" if shots == 0 else "For example:\n\n" + "\n\n".join([f"Question: {ex['question']['text']}\nAnswer: {ex['answers'][0]['text']}" for ex in all_data["train"].shuffle(seed=demo_seed(example["document"]["id"] + example["question"]["text"], seed)).select(range(shots))]) + "\n\nNow, use the following story to answer the question:\n\n"
     }, remove_columns=["document", "answers"])
 
     data = filter_length(data, 131072, "context")
@@ -226,7 +232,7 @@ def load_multi_lexsum(dataset, shots=0, max_samples=None, seed=42):
 
     all_data = all_data.map(lambda x: {
         "context": '\n\n'.join(x["sources"]),
-        "demo": "" if shots == 0 else "Example summaries:\n\n" + "\n\n".join(["Summary: {}".format(ex["summary/short"]) for ex in train_data.shuffle().select(range(shots))]) + "\n\nNow, write a summary of the following legal documents.\n",
+        "demo": "" if shots == 0 else "Example summaries:\n\n" + "\n\n".join(["Summary: {}".format(ex["summary/short"]) for ex in train_data.shuffle(seed=demo_seed(x["id"], seed)).select(range(shots))]) + "\n\nNow, write a summary of the following legal documents.\n",
         "answer": x["summary/short"],
         "question": "",
     })


### PR DESCRIPTION
Fixes #43.

`load_narrativeqa` and `load_multi_lexsum` pick demos with `Dataset.shuffle()` and no seed. Without a seed, `datasets` derives one from numpy's global RNG, which `--seed` doesn't set (eval.py only calls `random.seed`). So whether runs are reproducible depends on the backend: `HFModel` calls `transformers.set_seed`, which seeds numpy, but the API models (OpenAI, Anthropic, Gemini, Together, TGI) and SGLang don't, so each fresh run gets different demos for the same seed. A warm `datasets` cache hides it on one machine since the `map` result is reused; it shows up across machines or after clearing the cache. `longqa` and `summ` both use `shots: 2`, so the standard configs are affected.

The fix follows the ICL loader: each example gets its own seed (sha256 of its id plus `--seed`), so demos still vary across examples but are fixed for a given seed on any backend.

Tested both loaders on small local stand-in datasets, fresh process and cache per run: the same seed now gives identical demos with and without numpy seeded, seed 42 vs 43 gives different demos, and each example still gets its own set. One side effect: `HFModel` runs will get different (now fixed) demos than before for these two tasks, so scores may shift slightly vs. older runs.
